### PR TITLE
 Pets no longer cause client hitches in Nimbus Station and Forbidden Valley #493 

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -231,7 +231,8 @@ void Entity::Initialize()
 		m_Components.insert(std::make_pair(COMPONENT_TYPE_RACING_STATS, nullptr));
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, COMPONENT_TYPE_ITEM) > 0) {
+	PetComponent* petComponent;
+	if (compRegistryTable->GetByIDAndType(m_TemplateID, COMPONENT_TYPE_ITEM) > 0 && !TryGetComponent(COMPONENT_TYPE_PET, petComponent)) {
 		m_Components.insert(std::make_pair(COMPONENT_TYPE_ITEM, nullptr));
 	}
 

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -81,7 +81,7 @@ void PetComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpd
 {
     const bool tamed = m_Owner != LWOOBJID_EMPTY;
 
-    outBitStream->Write1(); // Dirty?
+    outBitStream->Write1(); // Always serialize as dirty for now
 
     outBitStream->Write<uint32_t>(static_cast<unsigned int>(m_Status));
     outBitStream->Write<uint32_t>(static_cast<uint32_t>(tamed ? m_Ability : PetAbilityType::Invalid)); // Something with the overhead icon?

--- a/dGame/dComponents/PetComponent.h
+++ b/dGame/dComponents/PetComponent.h
@@ -39,7 +39,7 @@ public:
      * @param bricks the bricks to try to complete the minigame with
      * @param clientFailed unused
      */
-    void TryBuild(std::vector<Brick>& bricks, bool clientFailed);
+    void TryBuild(uint32_t numBricks, bool clientFailed);
 
     /**
      * Handles a notification from the client regarding the completion of the pet minigame, adding the pet to their

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -3676,7 +3676,7 @@ void GameMessages::HandlePetTamingTryBuild(RakNet::BitStream* inStream, Entity* 
 		return;
 	}
 
-	petComponent->TryBuild(bricks, clientFailed);
+	petComponent->TryBuild(bricks.size(), clientFailed);
 }
 
 void GameMessages::HandleNotifyTamingBuildSuccess(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) 


### PR DESCRIPTION
Previously due to an error, pets were given item components even when pets need to be excluded from having item components. This would cause serialization issues on the client and the client would lag when loading pets in Nimbus Station and Forbidden valley. This also fixes the issue with the "You got X number of bricks out of Y!" error. This was happening because the client does all the work for checking the bricks and if the bricks are all correct, only then does the server send a TrybuildResult. Otherwise nothing should be sent.

All work is verified against packet captures from live, lcdr's toolset, and testing.
testing involved 2 clients and various combinations of taming pets and loading pets from bags. No behavior has changed for pets besides no more lag in the critical areas.
